### PR TITLE
use pre-commit.ci, remove workflow step running pre-commit. Add pyright to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,23 @@ on:
         branches: [main]
 
 jobs:
-    check:
+    # pyright can't run in pre-commit CI as it requires an internet connection
+    # so we instead run it directly as a GitHub action
+    pyright:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - name: Set up Python 3.12
+            - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: '3.12'
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip setuptools pre-commit
-            - name: Run checks
-              run: |
-                  pre-commit run --all-files
+                  cache: pip
+            - name: Install typing dependencies
+              run: pip install -r requirements-typing.txt
+            - uses: jakebailey/pyright-action@v2
+              with:
+                # Use exit code of 1 if warnings are reported.
+                  warnings: true
+
 
     test:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
     release:
         runs-on: ubuntu-latest
-        needs: [check, test]
+        needs: [pyright, test]
         if: github.repository == 'Zac-HD/flake8-trio' &&  github.ref == 'refs/heads/main'
         steps:
             - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 default_language_version:
     python: python3.12
 # pyright requires internet connection to run, which the pre-commit ci app doesn't have.
-# Not used in this repo.
+# it instead runs in a github action
 ci:
     skip: [pyright]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,9 +42,12 @@ repos:
             # ignore warnings about new version being available, no other warnings
             # are suppressed by this.
             entry: env PYRIGHT_PYTHON_IGNORE_WARNING=true pyright
-            args: [--pythonversion=3.11, --warnings]
+            # exit with non-zero on warnings
+            args: [--warnings]
+            # Required for pyright strict mode
+            # Mirrors content of requirements-typing.txt, as pre-commit does not allow
+            # reading from that for caching reasons.
             additional_dependencies:
-          # Required for pyright strict mode
                 - anyio
                 - flake8
                 - GitPython

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/python-trio/flake8-trio/main.svg)](https://results.pre-commit.ci/latest/github/python-trio/flake8-trio/main)
+[![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
 # flake8-trio
 
 A highly opinionated flake8 plugin for [Trio](https://github.com/python-trio/trio)-related problems.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/python-trio/flake8-trio/main.svg)](https://results.pre-commit.ci/latest/github/python-trio/flake8-trio/main)
 # flake8-trio
 
 A highly opinionated flake8 plugin for [Trio](https://github.com/python-trio/trio)-related problems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ warn_unused_ignores = false
 
 [tool.pyright]
 exclude = ["**/node_modules", "**/__pycache__", "**/.*", "tests/eval_files/*", "tests/autofix_files/*"]  # TODO: fix errors in eval/autofix files
+pythonVersion = "3.12"
 reportCallInDefaultInitializer = true
 reportImplicitStringConcatenation = false  # black generates implicit string concats
 reportMissingSuperCall = true

--- a/requirements-typing.txt
+++ b/requirements-typing.txt
@@ -1,0 +1,7 @@
+anyio
+flake8
+GitPython
+hypothesis
+hypothesmith
+pytest
+trio


### PR DESCRIPTION
Some minor shuffling around of things now that we have pre-commit.ci
A bit ugly to duplicate the typing dependencies, but since we don't pin those it's nbd.

pyright is in pre-commit primarily because I run it locally, but the pre-commit bot will now also bump versions of it, causing it to actually run in the CI action, and everything magically works out.

todo:
* edit the branch protection rules. Will do that just before merging.